### PR TITLE
Fix eval dataset subsampling bug in fine_tune

### DIFF
--- a/src/cell2sentence/csmodel.py
+++ b/src/cell2sentence/csmodel.py
@@ -174,6 +174,7 @@ class CSModel():
             sampled_eval_indices = sample(list(range(eval_dataset.num_rows)), k=max_eval_samples)
             sampled_eval_indices.sort()
             np.save(os.path.join(output_dir, 'sampled_eval_indices.npy'), np.array(sampled_eval_indices, dtype=np.int64))
+            eval_dataset = eval_dataset.select(sampled_eval_indices)
         
         # Define Trainer
         trainer = Trainer(


### PR DESCRIPTION
Fixes #2. Select the newly sampled indices from `eval_dataset` when `max_eval_samples` is specified.