### PR TITLE
Fix Trainer args

### DIFF
--- a/tutorials/c2s_tutorial_3_finetuning_on_new_datasets.ipynb
+++ b/tutorials/c2s_tutorial_3_finetuning_on_new_datasets.ipynb
@@ -676,7 +676,7 @@
     "    lr_scheduler_type=\"cosine\",\n",
     "    num_train_epochs=5, \n",
     "    eval_steps=50,\n",
-    "    evaluation_strategy=\"steps\",\n",
+    "    eval_strategy=\"steps\",\n",
     "    save_steps=100,\n",
     "    save_strategy=\"steps\",\n",
     "    save_total_limit=3,\n",


### PR DESCRIPTION
According to the [latest docs](https://huggingface.co/docs/transformers/en/main_classes/trainer#transformers.TrainingArguments.eval_strategy), `eval_strategy` should be used instead.
